### PR TITLE
Bump async-graphql to 2.10.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+-   Bump `async-graphql` to `2.10.*` to fix dependency resolution conflict while using latest async-graphql.
+
 ### Misc
 
 -  Add audit github action

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.9.15"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640d9d3f3d2ee7df7d64f1ce752877bfbcccfd146a4291a7eca69bcc89ffc17"
+checksum = "3fae8d9e26ef1e63d128b6a39da27b86070d6f52a0e31fb9613e084f1ef1242a"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.9.15"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b146a2869ab23a711721ae7e1d6f08013298f2f7814f5a21431134feed18f31"
+checksum = "01e95362be954a8e16074a56fbebd85b96b2ca239462286c6f3879a4b91fa915"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "2.9.15"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c9faa27abf0cc9969874a48ff6e439d46cbc6e19d36a73b1b88702ce06b7af"
+checksum = "265e65ea8b8f5e9083539adb78bccbc63697c06a460b8f978f687d8ed7cf136c"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "2.9.15"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d59b43a2116d78557d224d86da65b7b05f9bcbb8b2744bd6c50d18b3b69e29"
+checksum = "6e1c76e120c4ad75cdf8a0e49b95ddca050b609bda932b3aac94347c43088490"
 dependencies = [
  "bytes 1.0.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-std-comp = ["async-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 protobuf = { version = "2.25.1", features = ["bytes"] }
-async-graphql = {version = "2.9.*", features = ["tracing"] }
+async-graphql = {version = "2.10.*", features = ["tracing"] }
 tracing = "0.1.*"
 tracing-futures = { version = "0.2.5", default-features = false, features = ["tokio", "futures-03", "std"] }
 futures = "0.3.*"                 # An implementation of futures and streams featuring zero allocations, composability, and itera…


### PR DESCRIPTION
What this PR does / why we need it:

Bumps async-graphql to 2.10.*, fixing dependency resolution conflict while using latest async-graphql.

```
error: failed to select a version for `async-graphql`.
    ... required by package `async-graphql-extension-apollo-tracing v1.0.3`
    ... which is depended on by `redacted v0.1.0 (redacted)`
versions that meet the requirements `2.9.*` are: 2.9.15, 2.9.14, 2.9.13, 2.9.12, 2.9.11, 2.9.10, 2.9.9, 2.9.8, 2.9.7, 2.9.6, 2.9.5, 2.9.4, 2.9.3, 2.9.2, 2.9.1

all possible versions conflict with previously selected packages.

  previously selected package `async-graphql v2.10.0`
    ... which is depended on by `async-graphql-actix-web v2.10.0`
    ... which is depended on by `redacted v0.1.0 (redacted)`

failed to select a version for `async-graphql` which could resolve this conflict
```

Which issue(s) this PR fixes:
- N/A; no issues.
