### PR TITLE
Bump async-graphql from `2.10` to `3.0.7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.10.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fae8d9e26ef1e63d128b6a39da27b86070d6f52a0e31fb9613e084f1ef1242a"
+checksum = "bf244f203c8b1c25cee466b32212e689ef58f9674fa1307ff41576be41abfcdb"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -92,6 +92,7 @@ dependencies = [
  "indexmap",
  "mime",
  "multer",
+ "num-traits",
  "once_cell",
  "pin-project-lite",
  "regex",
@@ -106,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.10.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e95362be954a8e16074a56fbebd85b96b2ca239462286c6f3879a4b91fa915"
+checksum = "92af618631923f12c31d98cacd507b14400bd42a6ae4f23d60c2e8f2f909e724"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -143,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "2.10.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265e65ea8b8f5e9083539adb78bccbc63697c06a460b8f978f687d8ed7cf136c"
+checksum = "86d50f95aa06d606f91e802449fe8a23735eaff1d67ae6485b6d7f0e5608d645"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -156,11 +157,12 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "2.10.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1c76e120c4ad75cdf8a0e49b95ddca050b609bda932b3aac94347c43088490"
+checksum = "bae61bf2755097ec092ca75eff0e56db880ffc2722b3e01d112e21941504d34f"
 dependencies = [
  "bytes 1.0.1",
+ "indexmap",
  "serde",
  "serde_json",
 ]
@@ -966,6 +968,7 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-std-comp = ["async-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 protobuf = { version = "2.25.1", features = ["bytes"] }
-async-graphql = {version = "2.10.*", features = ["tracing"] }
+async-graphql = {version = "3.0.7", features = ["tracing"] }
 tracing = "0.1.*"
 tracing-futures = { version = "0.2.5", default-features = false, features = ["tokio", "futures-03", "std"] }
 futures = "0.3.*"                 # An implementation of futures and streams featuring zero allocations, composability, and itera…

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "compression")]
 use libflate::gzip;
 
+#[cfg(feature = "compression")]
 const TARGET_LOG_COMPRESSION: &str = "apollo-studio-extension-compression";
 
 #[cfg(feature = "compression")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl From<HTTPMethod> for Trace_HTTP_Method {
 /// * `protocol` - The http protocol, example: HTTP/1, HTTP/1.1, HTTP/2.
 /// * `status_code` - The status code return by your GraphQL API. It's a little weird to have to put it
 /// before executing the graphql function, it'll be changed later but usually it's just a 200.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ApolloTracingDataExt {
     pub userid: Option<String>,
     pub client_name: Option<String>,
@@ -147,22 +147,6 @@ pub struct ApolloTracingDataExt {
     pub secure: Option<bool>,
     pub protocol: Option<String>,
     pub status_code: Option<u32>,
-}
-
-impl Default for ApolloTracingDataExt {
-    fn default() -> Self {
-        ApolloTracingDataExt {
-            userid: None,
-            client_name: None,
-            client_version: None,
-            path: None,
-            host: None,
-            method: None,
-            secure: None,
-            protocol: None,
-            status_code: None,
-        }
-    }
 }
 
 impl ApolloTracing {
@@ -197,6 +181,7 @@ impl ApolloTracing {
         });
 
         let client = reqwest::Client::new();
+        #[allow(unused_mut)]
         let (sender, mut receiver) = channel::<(String, Trace)>(batch_target * 3);
 
         let header_tokio = Arc::clone(&header);
@@ -381,7 +366,7 @@ impl Extension for ApolloTracingExtension {
             .data::<ApolloTracingDataExt>()
             .ok()
             .cloned()
-            .unwrap_or_else(ApolloTracingDataExt::default);
+            .unwrap_or_default();
         let client_name = tracing_extension
             .client_name
             .unwrap_or_else(|| "no client name".to_string());

--- a/src/register.rs
+++ b/src/register.rs
@@ -69,7 +69,7 @@ pub async fn register<
                     executableSchemaId: "{}"
                     graphVariant: "{}"
                     platform: "{}"
-                    libraryVersion: "{}"
+                    libraryVersion: "async-studio-extension {}"
                     runtimeVersion: "{}"
                     userVersion: "{}"        
                   }}
@@ -92,7 +92,7 @@ pub async fn register<
         sha_from_schema,
         variant,
         platform,
-        format!("async-studio-extension {}", VERSION),
+        VERSION,
         RUNTIME_VERSION,
         user_version
     );


### PR DESCRIPTION
What this PR does / why we need it:

- Bump async-graphql from `2.10` to `3.0.7`
- Clippy clean

Which issue(s) this PR fixes:

